### PR TITLE
[Update #7] add error cases, make some macros deprecated

### DIFF
--- a/Sources/LuaSwift/LuaSwift+Error.swift
+++ b/Sources/LuaSwift/LuaSwift+Error.swift
@@ -9,6 +9,9 @@ import LuaSwiftCore
 /// Lua VMのエラー
 public enum LuaError: Error {
     
+    /// Yield (LUA\_YIELD)
+    case Yield
+    
     /// ランタイムエラー (LUA\_ERRRUN)
     case RuntimeError
     
@@ -37,6 +40,8 @@ public enum LuaError: Error {
     /// - Parameter statusCode: ステータスコード
     init?(statusCode: Int32) {
         switch statusCode {
+        case LUA_YIELD:
+            self = .Yield
         case LUA_ERRRUN:
             self = .RuntimeError
         case LUA_ERRSYNTAX:

--- a/Sources/LuaSwift/LuaSwift+Exec.swift
+++ b/Sources/LuaSwift/LuaSwift+Exec.swift
@@ -19,8 +19,13 @@ public extension Lua {
     /// 式を評価する
     /// - Parameter statement: 式
     func eval(_ statement: String) throws {
-        let result = luaL_dostring(state, s: statement)
-        guard result == 0 else { throw LuaError(statusCode: result)! }
+        // luaL_dostring マクロを使うとloadstringのエラーが握り潰されてしまうため、2段階に分割
+        
+        let loadResult = luaL_loadstring(state, statement)
+        guard loadResult == 0 else { throw LuaError(statusCode: loadResult)! }
+        
+        let callResult = lua_pcall(state, 0, LUA_MULTRET, 0)
+        guard callResult == 0 else { throw LuaError(statusCode: callResult)! }
     }
     
 }

--- a/Sources/LuaSwift/LuaSwift+Macros.swift
+++ b/Sources/LuaSwift/LuaSwift+Macros.swift
@@ -190,6 +190,7 @@ internal let LUAL_NUMSIZES = MemoryLayout<lua_Integer>.size * 16 + MemoryLayout<
 }
 
 /// #define luaL_dofile(L, fn) (luaL_loadfile(L, fn) || lua_pcall(L, 0, LUA_MULTRET, 0))
+@available(*, deprecated, message: "This macros return value is incompliant to rawValue of LuaError.")
 @inline(__always) internal func luaL_dofile(_ L: LuaState, _ fn: UnsafePointer<CChar>!) -> Int32 {
     guard luaL_loadfile(L, fn) == 0 else {return 1}
     return lua_pcall(L, 0, LUA_MULTRET, 0)
@@ -197,6 +198,7 @@ internal let LUAL_NUMSIZES = MemoryLayout<lua_Integer>.size * 16 + MemoryLayout<
 
 
 /// #define luaL_dostring(L, s) (luaL_loadstring(L, s) || lua_pcall(L, 0, LUA_MULTRET, 0))
+@available(*, deprecated, message: "This macros return value is incompliant to rawValue of LuaError.")
 @inline(__always) internal func luaL_dostring(_ L: LuaState, s: UnsafePointer<CChar>!) -> Int32 {
     guard luaL_loadstring(L, s) == 0 else {return 1}
     return lua_pcall(L, 0, LUA_MULTRET, 0)

--- a/Tests/LuaSwiftTests/test_LuaExec.swift
+++ b/Tests/LuaSwiftTests/test_LuaExec.swift
@@ -44,10 +44,10 @@ final class testLuaExec: XCTestCase {
         --
         -- FizzBuzz
         --
-
+        
         -- 最大値を設定
         local limit = \(limit)
-
+        
         --カウントアップ
         for n = 1, limit do
             if n % 3 == 0 and n % 5 == 0 then
@@ -79,6 +79,22 @@ final class testLuaExec: XCTestCase {
         
         // 同じ結果が得られるはず
         XCTAssertEqual(expected, outputStream)
+    }
+    
+    /// yieldのテスト
+    func testYield() throws {
+        let lua = Lua()
+        
+        // これは通る
+        let value = 123
+        try lua.eval("a = \(value)")
+        
+        // これは通らない となるとREPLは一体どんな仕組みになっているのか…?
+        do {
+            try lua.eval("a")
+        } catch LuaError.SyntaxError {
+            print("Syntax error: \(try lua.get() as String)")
+        }
     }
     
 }


### PR DESCRIPTION
 - add LuaError.Yield
 - make luaL_dofile and luaL_dostring deprecated because these are not complianted to LuaError rawValue